### PR TITLE
NativeScript 3.0 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ Thanks to TJ VanToll for the awesome animated gif.
 
 ## Installation 
 
-tns plugin add nativescript-orientation  
 
+##### NativeScript 3.x.x
+tns plugin add nativescript-orientation
+
+##### NativeScript 2.x.x
+tns plugin add nativescript-orientation@1.6.1
 
 ## Usage
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,12 +2,15 @@
   "nativescript": {
     "id": "org.nativescript.demo",
     "tns-android": {
-      "version": "2.1.1"
+      "version": "3.0.0"
+    },
+    "tns-ios": {
+      "version": "3.0.0"
     }
   },
   "dependencies": {
     "nativescript-orientation": "file:..",
-    "tns-core-modules": "^2.1.0"
+    "tns-core-modules": "^3.0.0"
   },
   "devDependencies": {
     "babel-traverse": "6.13.0",

--- a/orientation.js
+++ b/orientation.js
@@ -33,7 +33,7 @@ module.exports = orientation;
 /**
  * Helper function hooked to the Application to get the current orientation
  */
-if (global.android) {
+if (application.android) {
 	orientation.getOrientation = function () {
 		var context = getContext();
 		var orientation = context.getSystemService("window").getDefaultDisplay().getOrientation();
@@ -115,8 +115,7 @@ if (global.android) {
 
 	};
 
-} else if (global.NSObject && global.UIDevice) {
-
+} else if (application.ios) {
 	setupiOSController();
 	orientation.getOrientation = function () {
 		var device = utils.ios.getter(UIDevice, UIDevice.currentDevice);
@@ -299,7 +298,6 @@ var applyOrientationToPage = function(page, args){
 
 
 	page._refreshCss();
-	page.style._resetCssValues();
 	page._applyStyleFromScope();
 	if (args != null) {
 		view.eachDescendant(page, resetChildrenRefreshes);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nativescript-orientation",
-  "version": "1.6.1",
+  "version": "2.0.0",
   "description": "A NativeScript plugin to deal with Declarative UI and Screen Orientation",
   "main": "orientation",
   "nativescript": {
 	"platforms": {
-		"android": "2.3.0",
-		"ios": "2.3.0"
+		"android": "3.0.0",
+		"ios": "3.0.0"
 	}
   },
   "repository": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "nativescript-globalevents": "^1.1.0",
-    "nativescript-dom": "^1.0.0"
+    "nativescript-dom": "^2.0.0"
   },
   "keywords": [
     "NativeScript", "orientation", "landscape", "ios", "android"


### PR DESCRIPTION
Updated the plugin and its demo to build against tns-core-module@3.0.0.

* the page.style._resetCssValues(); is removed in NativeScript 3.0 but as far as I see something similar is called inside _refreshCss.
* the readme is updated in order to specify the NativeScript 2.* support 