### PR TITLE
NS 3.0 and Android Orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ Thanks to TJ VanToll for the awesome animated gif.
 
 ## Installation 
 
-tns plugin add nativescript-orientation  
 
+##### NativeScript 3.x.x
+tns plugin add nativescript-orientation
+
+##### NativeScript 2.x.x
+tns plugin add nativescript-orientation@1.6.1
 
 ## Usage
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,12 +2,15 @@
   "nativescript": {
     "id": "org.nativescript.demo",
     "tns-android": {
-      "version": "2.1.1"
+      "version": "3.0.0"
+    },
+    "tns-ios": {
+      "version": "3.0.0"
     }
   },
   "dependencies": {
     "nativescript-orientation": "file:..",
-    "tns-core-modules": "^2.1.0"
+    "tns-core-modules": "^3.0.0"
   },
   "devDependencies": {
     "babel-traverse": "6.13.0",

--- a/orientation.js
+++ b/orientation.js
@@ -33,7 +33,7 @@ module.exports = orientation;
 /**
  * Helper function hooked to the Application to get the current orientation
  */
-if (global.android) {
+if (application.android) {
 	orientation.getOrientation = function () {
 		var context = getContext();
 		var orientation = context.getSystemService("window").getDefaultDisplay().getOrientation();
@@ -115,8 +115,7 @@ if (global.android) {
 
 	};
 
-} else if (global.NSObject && global.UIDevice) {
-
+} else if (application.ios) {
 	setupiOSController();
 	orientation.getOrientation = function () {
 		var device = utils.ios.getter(UIDevice, UIDevice.currentDevice);
@@ -299,7 +298,6 @@ var applyOrientationToPage = function(page, args){
 
 
 	page._refreshCss();
-	page.style._resetCssValues();
 	page._applyStyleFromScope();
 	if (args != null) {
 		view.eachDescendant(page, resetChildrenRefreshes);

--- a/orientation.js
+++ b/orientation.js
@@ -35,17 +35,16 @@ module.exports = orientation;
  */
 if (application.android) {
 	orientation.getOrientation = function () {
-		var context = getContext();
-		var orientation = context.getSystemService("window").getDefaultDisplay().getOrientation();
-		switch (orientation) {
-			case 1: /* LANDSCAPE */
-				return enums.DeviceOrientation.landscape;
-			case 0: /* PORTRAIT */
-				return enums.DeviceOrientation.portrait;
-			default:
-				return false;
-		}
-	};
+        var orientation = getContext().getResources().getConfiguration().orientation;
+        switch (orientation) {
+            case 1: /* ORIENTATION_PORTRAIT (0x00000001) */
+                return enums.DeviceOrientation.portrait;
+            case 2: /* ORIENTATION_LANDSCAPE (0x00000002) */
+                return enums.DeviceOrientation.landscape;
+            default: /* ORIENTATION_UNDEFINED (0x00000000) */
+                return false;
+        }
+    };
 
 	orientation.enableRotation = function() {
 		if (!application.android || !application.android.foregroundActivity) {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nativescript-orientation",
-  "version": "1.6.1",
+  "version": "2.0.0",
   "description": "A NativeScript plugin to deal with Declarative UI and Screen Orientation",
   "main": "orientation",
   "nativescript": {
 	"platforms": {
-		"android": "2.3.0",
-		"ios": "2.3.0"
+		"android": "3.0.0",
+		"ios": "3.0.0"
 	}
   },
   "repository": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "nativescript-globalevents": "^1.1.0",
-    "nativescript-dom": "^1.0.0"
+    "nativescript-dom": "^2.0.0"
   },
   "keywords": [
     "NativeScript", "orientation", "landscape", "ios", "android"


### PR DESCRIPTION
This PR includes #14 (which covers #13) and also seeks to resolve the same issue as #12.

I found that both `getDefaultDisplay().getOrientation()` and `getDefaultDisplay().getRotation()` were not reliable for detecting Landscape vs. Portrait depending on whether the app was launched in Landscape mode or what was considered the device'ss "Natural" orientation.

This solution appears to consistently detect the orientation, regardless of default device or launch orientation.

I can also confirm the changes for 3.0 appear to be working since I have been using @DimitarTachev 's branch for several weeks now with my 3.0.0+ project.